### PR TITLE
Fixed some fail report by replacing the use of package BLOCK.

### DIFF
--- a/t/memleak.t
+++ b/t/memleak.t
@@ -8,7 +8,8 @@ use lib 'lib';
 
 ## no critic qw(Subroutines::ProhibitCallsToUndeclaredSubs)
 
-package MyApp {
+package MyApp;
+
     use Dancer2;
     use Dancer2::Plugin::ParamTypes;
 
@@ -17,7 +18,8 @@ package MyApp {
 
     get '/' => with_types [ [ 'query', 'id', 'Int' ] ] =>
         sub {1};
-}
+
+package main;
 
 my $app    = MyApp->to_app;
 my $runner = Dancer2->runner;


### PR DESCRIPTION
Hi @xsawyerx 

Please review the PR.
Since the package BLOCK was introduced in Perl v5.14, these test FAIL are in environment having < 5.14.

https://www.cpantesters.org/cpan/report/e9ea338a-e84b-11e7-9abe-a171f40b351c
https://www.cpantesters.org/cpan/report/6851a7d4-e7da-11e7-9abe-a171f40b351c

Many Thanks.
Best Regards,
Mohammad S Anwar