### PR TITLE
add support of multiple entries for one parameter name

### DIFF
--- a/lib/Dancer2/Plugin/ParamTypes.pm
+++ b/lib/Dancer2/Plugin/ParamTypes.pm
@@ -115,13 +115,14 @@ sub with_types {
             or Carp::croak('You need to provide a "missing" action');
 
         my $src = join ':', sort @{$sources};
-        $params_to_check{$src}{$name} = {
+        push @{ $params_to_check{$src} },
+          {
             'optional' => $is_optional,
             'source'   => $src,
             'name'     => $name,
             'type'     => $type,
             'action'   => $action,
-        };
+          };
     }
 
     # Couldn't prove yet that this is required, but it makes sense to me
@@ -140,10 +141,8 @@ sub with_types {
 
         # Only check if anything was supplied
         foreach my $source ( keys %params_to_check ) {
-            foreach my $name ( keys %{ $params_to_check{$source} } ) {
-                my @sources = split /:/xms, $source;
-                my $details = $params_to_check{$source}{$name};
-
+            my @sources = split /:/xms, $source;
+            foreach my $details ( @{ $params_to_check{$source} } ) {
                 if ( @sources == 1 ) {
                     $plugin->run_check($details)
                         or

--- a/t/multiple_param_entries.t
+++ b/t/multiple_param_entries.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+
+use lib '.';
+use strict;
+use warnings;
+
+use HTTP::Request::Common;
+use Plack::Test;
+use Test::More 'tests' => 3;
+use t::lib::Utils;
+
+{
+
+    package MyApp;
+    use Dancer2;
+    use Dancer2::Plugin::ParamTypes;
+
+    register_type_check( NotEmpty => sub { $_[0] } );
+    register_type_check( Int      => sub { Scalar::Util::looks_like_number( $_[0] ) } );
+
+    get '/query' => with_types [ [ 'query', 'id', 'NotEmpty' ], [ 'query', 'id', 'Int' ] ] => sub {
+        return 'query';
+    };
+}
+
+my $test = Plack::Test->create( MyApp->to_app );
+
+subtest 'Correctly handled proper parameters' => sub {
+    successful_test( $test, GET('/query?id=4'), 'query' );
+};
+
+subtest 'Failing missing parameters' => sub {
+    missing_test( $test, GET('/query'), 'query', 'id' );
+};
+
+subtest 'Failing incorrect parameters' => sub {
+    failing_test( $test, GET('/query?id='),  'query', 'id', 'NotEmpty', );
+    failing_test( $test, GET('/query?id=k'), 'query', 'id', 'Int', );
+};


### PR DESCRIPTION
for example,
all these checks are being processed, not just the last one:
```
    [ 'body', 'email', 'require', ],
    [ 'body', 'email', 'email', ]
```

P.S.
as a side-effect the code should be a little faster (using array instead of hash)